### PR TITLE
Vacancylist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ gem 'sinatra'
 gem 'dotenv'
 gem 'eventmachine'
 gem 'faye-websocket'
-gem 'http'
-gem 'json'
 
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'sinatra'
 gem 'dotenv'
 gem 'eventmachine'
 gem 'faye-websocket'
+gem 'http'
+gem 'json'
 
 
 group :development, :test do

--- a/slack-referbot.rb
+++ b/slack-referbot.rb
@@ -1,4 +1,5 @@
 require 'slack-ruby-bot'
 require 'slack-ruby-client'
 require 'slack-referbot/commands/calculate'
+require 'slack-referbot/commands/vacancylist'
 require 'slack-referbot/bot'

--- a/slack-referbot/commands/vacancylist.rb
+++ b/slack-referbot/commands/vacancylist.rb
@@ -1,0 +1,21 @@
+require 'http'
+require 'json'
+
+module SlackReferbot
+  module Commands
+    class List < SlackRubyBot::Commands::Base
+      command 'list' do |client, data, _match|
+
+        offers = HTTP.get('https://api.recruitee.com/c/referbot/careers/offers')
+
+        test1 = JSON.parse(offers, symbolize_names: true)
+          contents = test1[:offers]
+          contents.each do |content|
+            client.say(channel: data.channel, text: "#{content[:id]}, #{content[:title]} \n #{content[:careers_url]} \n")
+          end
+
+        client.say(channel: data.channel, text: "")
+      end
+    end
+  end
+end

--- a/slack-referbot/commands/vacancylist.rb
+++ b/slack-referbot/commands/vacancylist.rb
@@ -10,8 +10,8 @@ module SlackReferbot
 
         test1 = JSON.parse(offers, symbolize_names: true)
           contents = test1[:offers]
-          contents.each do |content|
-            client.say(channel: data.channel, text: "#{content[:id]}, #{content[:title]} \n #{content[:careers_url]} \n")
+          contents.each_with_index do |content, index|
+            client.say(channel: data.channel, text: "#{index + 1}, #{content[:title]} \n #{content[:careers_url]} \n")
           end
 
         client.say(channel: data.channel, text: "")

--- a/slack-referbot/commands/vacancylist.rb
+++ b/slack-referbot/commands/vacancylist.rb
@@ -3,7 +3,7 @@ require 'json'
 
 module SlackReferbot
   module Commands
-    class List < SlackRubyBot::Commands::Base
+    class Vacancylist < SlackRubyBot::Commands::Base
       command 'list' do |client, data, _match|
 
         offers = HTTP.get('https://api.recruitee.com/c/referbot/careers/offers')


### PR DESCRIPTION
Added a new command to referbot called vacancylist

You can use the command by: <botname> list

It connects to the recruitee api and fetches a JSON list of vacancies. 
It parses the list 
It displays the name of the vacancy, a link to the recruitee site and an index number 1 to n

I added http and json to the gemfile
